### PR TITLE
Tasklist: add duplicate checks

### DIFF
--- a/src/main/java/duke/domain/Deadline.java
+++ b/src/main/java/duke/domain/Deadline.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import duke.constants.Constants;
 import duke.shared.DateHelpers;
+import duke.shared.GenericHelpers;
 
 /**
  * Encapsulates a task with a deadline.
@@ -79,5 +80,22 @@ public class Deadline extends Task {
         String base = super.toString();
         String result = String.format("%s (by: %s)", base, Constants.Display.DATETIME_FORMATTER.format(dueDate));
         return result;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o instanceof Deadline) {
+            Deadline d = (Deadline) o;
+            return this.getName().equals(d.getName()) && this.dueDate.equals(d.dueDate);
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return GenericHelpers.combineHashCodes(super.hashCode(), dueDate.hashCode());
     }
 }

--- a/src/main/java/duke/domain/Event.java
+++ b/src/main/java/duke/domain/Event.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import duke.shared.DateHelpers;
 import duke.shared.DateRange;
+import duke.shared.GenericHelpers;
 
 /**
  * Encapsulates a task taking place over a specified period of time.
@@ -103,5 +104,22 @@ public class Event extends Task {
         String base = super.toString();
         String result = String.format("%s (at: %s)", base, dateRange);
         return result;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o instanceof Event) {
+            Event e = (Event) o;
+            return this.getName().equals(e.getName()) && this.dateRange.equals(e.dateRange);
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return GenericHelpers.combineHashCodes(super.hashCode(), this.dateRange.hashCode());
     }
 }

--- a/src/main/java/duke/domain/Task.java
+++ b/src/main/java/duke/domain/Task.java
@@ -118,4 +118,9 @@ public class Task implements PrintableMixin {
         return String.format("%s %s %s",
                 getTypeString() == null ? "" : StringHelpers.bracketWrap(getTypeString()), state, getName());
     }
+
+    @Override
+    public int hashCode() {
+        return getName().hashCode();
+    }
 }

--- a/src/main/java/duke/domain/TaskList.java
+++ b/src/main/java/duke/domain/TaskList.java
@@ -1,0 +1,76 @@
+package duke.domain;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+public class TaskList implements Iterable<Task> {
+    private List<Task> tasks;
+    private Set<Task> taskSet;
+
+    /**
+     * Creates an empty TaskList.
+     */
+    public TaskList() {
+        tasks = new ArrayList<>();
+        taskSet = new HashSet<>();
+    }
+
+    /**
+     * Creates a TaskList with contents from the given list.
+     * This is meant to be used to create a temporary wrapper around a list, hence
+     * the task set is not updated.
+     * @param taskList List of tasks to be placed into task list.
+     */
+    public TaskList(List<Task> taskList) {
+        tasks = taskList;
+    }
+
+    public int size() {
+        return tasks.size();
+    }
+
+    /**
+     * Adds a task to the list. Does not allow duplicates.
+     *
+     * @param task Task to be added to the list.
+     * @return Whether a task is actually added. False if the task is a duplicate.
+     */
+    public boolean add(Task task) {
+        if (taskSet.contains(task)) {
+            return false;
+        }
+        tasks.add(task);
+        taskSet.add(task);
+        return true;
+    }
+
+    public Task get(int index) {
+        return tasks.get(index);
+    }
+
+    /**
+     * Removes the task at the given index.
+     *
+     * @param index Index of task to be removed.
+     * @return The removed task.
+     */
+    public Task remove(int index) {
+        Task removedTask = tasks.remove(index);
+        assert removedTask != null;
+        tasks.remove(removedTask);
+        return removedTask;
+    }
+
+    public Stream<Task> stream() {
+        return tasks.stream();
+    }
+
+    @Override
+    public Iterator<Task> iterator() {
+        return tasks.iterator();
+    }
+}

--- a/src/main/java/duke/domain/Todo.java
+++ b/src/main/java/duke/domain/Todo.java
@@ -35,4 +35,16 @@ public class Todo extends Task {
         String name = fields[2];
         return new Todo(name, isDone);
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o instanceof Todo) {
+            Todo e = (Todo) o;
+            return this.getName().equals(e.getName());
+        } else {
+            return false;
+        }
+    }
 }

--- a/src/main/java/duke/shared/DateRange.java
+++ b/src/main/java/duke/shared/DateRange.java
@@ -137,4 +137,21 @@ public class DateRange {
         assert isValid(); // can only print valid date ranges
         return String.format("between %s and %s", start, end);
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o instanceof DateRange) {
+            DateRange d = (DateRange) o;
+            return this.start.equals(d.start) && this.end.equals(d.end);
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return GenericHelpers.combineHashCodes(start.hashCode(), end.hashCode());
+    }
 }

--- a/src/main/java/duke/shared/DateRange.java
+++ b/src/main/java/duke/shared/DateRange.java
@@ -134,7 +134,7 @@ public class DateRange {
     public String toString() {
         String start = Constants.Display.DATETIME_FORMATTER.format(this.start);
         String end = Constants.Display.DATETIME_FORMATTER.format(this.end);
-        assert isValid(); // can only print valid date ranges
+        assert !isInvalid(); // can only print valid date ranges
         return String.format("between %s and %s", start, end);
     }
 

--- a/src/main/java/duke/shared/GenericHelpers.java
+++ b/src/main/java/duke/shared/GenericHelpers.java
@@ -1,0 +1,19 @@
+package duke.shared;
+
+public class GenericHelpers {
+    /**
+     * Reference
+     * https://stackoverflow.com/questions/9648305/creating-a-hashcode-method-java
+     *
+     * Generates a composite hashcode given multiple hashcodes.
+     *
+     * @param codes Hashcodes to be combined.
+     */
+    public static int combineHashCodes(int... codes) {
+        int generatedCode = 1;
+        for (int i = 0; i < codes.length; i++) {
+            generatedCode = generatedCode * 31 + codes[i];
+        }
+        return generatedCode;
+    }
+}


### PR DESCRIPTION
Tasklist allows identical tasks (e.g. todos with the same name) to be
added.

This worsens the user experience as users need to keep track of
duplicate tasks by themselves.

Encapsulating the list of tasks in its own class allows
additional behavior to be added that is not provided by a regular
ArrayList. One of this is checking of duplicates when inserting into
the list.

Let's create a class called TaskList that encapsulates the
aforementioned behavior.