### PR TITLE
Refactor commands to separate class

### DIFF
--- a/src/main/java/duke/Duke.java
+++ b/src/main/java/duke/Duke.java
@@ -1,7 +1,7 @@
 package duke;
 
 import duke.views.cli.Cli;
-import duke.views.cli.strategies.MultiType;
+import duke.views.cli.strategies.MultiTypeDelegated;
 import duke.views.gui.Launcher;
 import javafx.application.Application;
 
@@ -19,7 +19,7 @@ public class Duke {
      * Runs the CLI application.
      */
     public static void runCli() {
-        Cli chatbot = new Cli(new MultiType());
+        Cli chatbot = new Cli(new MultiTypeDelegated());
         chatbot.main();
     }
 

--- a/src/main/java/duke/interfaces/StringProducer.java
+++ b/src/main/java/duke/interfaces/StringProducer.java
@@ -1,0 +1,5 @@
+package duke.interfaces;
+
+public interface StringProducer {
+    String produce(String query);
+}

--- a/src/main/java/duke/views/InteractionLayer.java
+++ b/src/main/java/duke/views/InteractionLayer.java
@@ -5,7 +5,7 @@ import java.util.List;
 import duke.constants.Constants;
 import duke.views.cli.Greeter;
 import duke.views.cli.Loader;
-import duke.views.cli.strategies.RespondWith;
+import duke.views.cli.strategies.RespondWithDelegated;
 
 public interface InteractionLayer {
 
@@ -13,7 +13,7 @@ public interface InteractionLayer {
 
     Loader getLoader();
 
-    RespondWith getResponder();
+    RespondWithDelegated getResponder();
 
     /**
      * Runs before the application becomes responsive to user input.

--- a/src/main/java/duke/views/cli/Cli.java
+++ b/src/main/java/duke/views/cli/Cli.java
@@ -4,7 +4,7 @@ import java.util.Scanner;
 
 import duke.interfaces.PrintableMixin;
 import duke.views.InteractionLayer;
-import duke.views.cli.strategies.RespondWith;
+import duke.views.cli.strategies.RespondWithDelegated;
 
 /**
  * Encapsulates the command line interface. Listens to and generates response to
@@ -13,7 +13,7 @@ import duke.views.cli.strategies.RespondWith;
 public class Cli implements InteractionLayer, PrintableMixin {
     protected Loader loader;
     protected Greeter greeter;
-    protected RespondWith responder;
+    protected RespondWithDelegated responder;
     protected Scanner sc;
 
     /**
@@ -22,7 +22,7 @@ public class Cli implements InteractionLayer, PrintableMixin {
      * @param responder A parser of user input and generates a suitable response
      *                  when fed input.
      */
-    public Cli(RespondWith responder) {
+    public Cli(RespondWithDelegated responder) {
         loader = new Loader();
         greeter = new Greeter();
         this.responder = responder;
@@ -40,7 +40,7 @@ public class Cli implements InteractionLayer, PrintableMixin {
     }
 
     @Override
-    public RespondWith getResponder() {
+    public RespondWithDelegated getResponder() {
         return responder;
     }
 

--- a/src/main/java/duke/views/cli/strategies/MultiType.java
+++ b/src/main/java/duke/views/cli/strategies/MultiType.java
@@ -120,7 +120,8 @@ public class MultiType extends RespondWith {
         assert query != null;
         try {
             int index = Integer.parseInt(query.substring(done.length()).strip()) - 1;
-            if (index >= userTasks.size() || index < 0) {
+            boolean isWithinBounds = index >= userTasks.size() || index < 0;
+            if (!isWithinBounds) {
                 throw DukeException.createIndexOutOfBoundsException(userTasks.size(), index + 1);
             }
             Task task = userTasks.get(index);

--- a/src/main/java/duke/views/cli/strategies/MultiTypeDelegated.java
+++ b/src/main/java/duke/views/cli/strategies/MultiTypeDelegated.java
@@ -1,0 +1,110 @@
+package duke.views.cli.strategies;
+
+import java.util.List;
+
+import duke.constants.Constants;
+import duke.domain.Deadline;
+import duke.domain.Event;
+import duke.domain.Task;
+import duke.domain.TaskList;
+import duke.domain.Todo;
+import duke.shared.DukeException;
+import duke.shared.DukeException.ExceptionCode;
+import duke.views.cli.strategies.commands.AddDeadlineCommand;
+import duke.views.cli.strategies.commands.AddEventCommand;
+import duke.views.cli.strategies.commands.AddTodoCommand;
+import duke.views.cli.strategies.commands.DeleteCommand;
+import duke.views.cli.strategies.commands.FindCommand;
+import duke.views.cli.strategies.commands.ListCommand;
+import duke.views.cli.strategies.commands.MarkDoneCommand;
+import duke.views.cli.strategies.commands.OccurringOnCommand;
+
+/**
+ * A responder that is able to handle tasks with CRUD functionality.
+ */
+public class MultiTypeDelegated extends RespondWithDelegated {
+
+    private final String list = "list";
+    private final String done = "done";
+    private final String todo = "todo";
+    private final String deadline = "deadline";
+    private final String event = "event";
+    private final String delete = "delete";
+    private final String on = "on";
+    private final String find = "find";
+
+    private final TaskList userTasks;
+
+    /**
+     * Creates a responder that handles multiple types of tasks.
+     */
+    public MultiTypeDelegated() {
+        userTasks = new TaskList();
+        commands.put(list, ListCommand.getInstance(userTasks));
+        commands.put(done, MarkDoneCommand.getInstance(userTasks));
+        commands.put(todo, AddTodoCommand.getInstance(userTasks));
+        commands.put(deadline, AddDeadlineCommand.getInstance(userTasks));
+        commands.put(event, AddEventCommand.getInstance(userTasks));
+        commands.put(delete, DeleteCommand.getInstance(userTasks));
+        commands.put(on, OccurringOnCommand.getInstance(userTasks));
+        commands.put(find, FindCommand.getInstance(userTasks));
+    }
+
+    @Override
+    public Task rehydrateFromString(String s) {
+        String[] fields = s.split(Constants.Storage.PERSISTENCE_SEPARATOR_REGEX, -1);
+        for (int i = 0; i < fields.length; i++) {
+            fields[i] = fields[i].strip();
+        }
+        String typeString = fields[0];
+        Task task = null;
+        switch (typeString) {
+        case Todo.TYPE_STRING:
+            task = Todo.generateFromString(fields);
+            break;
+        case Event.TYPE_STRING:
+            task = Event.generateFromString(fields);
+            break;
+        case Deadline.TYPE_STRING:
+            task = Deadline.generateFromString(fields);
+            break;
+        default:
+            throw new DukeException(ExceptionCode.UNPROCESSABLE_ENTITY);
+        }
+
+        return task;
+    }
+
+    @Override
+    public String persistToStore() {
+        StringBuilder stringBuilder = new StringBuilder();
+        for (Task task : userTasks) {
+            List<String> fields = task.getStorageFields();
+            String stringToStore = String.join(Constants.Storage.PERSISTENCE_SEPARATOR_PRETTY, fields);
+            stringBuilder.append(stringToStore);
+            stringBuilder.append(System.lineSeparator());
+        }
+        return stringBuilder.toString();
+    }
+
+    @Override
+    public void load(List<String> dataList) {
+        for (String data : dataList) {
+            this.userTasks.add(rehydrateFromString(data));
+        }
+    }
+
+    @Override
+    public String respond(String query) {
+        assert query != null;
+        try {
+            String specialResponse = super.respond(query);
+            if (specialResponse != null) {
+                return specialResponse;
+            }
+            throw new DukeException(DukeException.ExceptionCode.UNPROCESSABLE_ENTITY);
+        } catch (DukeException e) {
+            return e.getMessage() + System.lineSeparator();
+        }
+    }
+}

--- a/src/main/java/duke/views/cli/strategies/RespondWithDelegated.java
+++ b/src/main/java/duke/views/cli/strategies/RespondWithDelegated.java
@@ -3,26 +3,27 @@ package duke.views.cli.strategies;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 
 import duke.constants.Constants;
 import duke.shared.StringHelpers;
+import duke.views.cli.strategies.commands.ByeCommand;
+import duke.views.cli.strategies.commands.Command;
 
 /**
  * A template class for responders that gives a string response upon receiving
  * string input.
  */
-public abstract class RespondWith {
+public abstract class RespondWithDelegated {
 
     /**
      * A mapping storing commandName, function pairs. The function will be called
      * when the given input matches the command.
      */
-    protected Map<String, Function<String, String>> commands = new HashMap<>();
+    protected Map<String, Command> commands = new HashMap<>();
     protected String endMessage = "bye";
 
-    public RespondWith() {
-        commands.put("bye", this::bye);
+    public RespondWithDelegated() {
+        commands.put("bye", new ByeCommand());
     }
 
 
@@ -34,17 +35,12 @@ public abstract class RespondWith {
      */
     public String respond(String query) {
 
-        Function<String, String> f = commands.get(query.split(" ")[0]);
+        Command f = commands.get(query.split(" ")[0]);
         if (f != null) {
-            return f.apply(query);
+            return f.produce(query);
         }
         return null;
 
-    }
-
-
-    private String bye(String _query) {
-        return "See you again" + System.lineSeparator();
     }
 
     /**
@@ -77,5 +73,7 @@ public abstract class RespondWith {
         return "";
     }
 
-    public void load(List<String> dataList) { }
+    public void load(List<String> dataList) {
+
+    }
 }

--- a/src/main/java/duke/views/cli/strategies/commands/AddDeadlineCommand.java
+++ b/src/main/java/duke/views/cli/strategies/commands/AddDeadlineCommand.java
@@ -1,0 +1,36 @@
+package duke.views.cli.strategies.commands;
+
+import duke.domain.Deadline;
+import duke.domain.Task;
+import duke.domain.TaskList;
+import duke.shared.DukeException;
+
+public class AddDeadlineCommand extends TaskCommand {
+    private static Command singleInstance;
+
+    public AddDeadlineCommand(TaskList taskList) {
+        super(taskList);
+    }
+
+    public static Command getInstance(TaskList taskList) {
+        if (singleInstance == null) {
+            singleInstance = new AddDeadlineCommand(taskList);
+        }
+        return singleInstance;
+    }
+
+    @Override
+    public String produce(String query) throws DukeException {
+        assert query != null;
+        String[] queries = query.substring(deadline.length()).split("/by");
+        if (queries.length != 2) {
+            throw DukeException.createArgumentCountException(2, queries.length);
+        }
+        Task task = new Deadline(queries[0].strip(), queries[1].strip());
+        boolean isUnique = userTasks.add(task);
+        if (!isUnique) {
+            return getDuplicateMessage();
+        }
+        return formatAdd(task);
+    }
+}

--- a/src/main/java/duke/views/cli/strategies/commands/AddEventCommand.java
+++ b/src/main/java/duke/views/cli/strategies/commands/AddEventCommand.java
@@ -1,0 +1,36 @@
+package duke.views.cli.strategies.commands;
+
+import duke.domain.Event;
+import duke.domain.Task;
+import duke.domain.TaskList;
+import duke.shared.DukeException;
+
+public class AddEventCommand extends TaskCommand {
+    private static Command singleInstance;
+
+    public AddEventCommand(TaskList taskList) {
+        super(taskList);
+    }
+
+    public static Command getInstance(TaskList taskList) {
+        if (singleInstance == null) {
+            singleInstance = new AddEventCommand(taskList);
+        }
+        return singleInstance;
+    }
+
+    @Override
+    public String produce(String query) throws DukeException {
+        assert query != null;
+        String[] queries = query.substring(event.length()).split("/at");
+        if (queries.length != 2) {
+            throw DukeException.createArgumentCountException(2, queries.length);
+        }
+        Task task = new Event(queries[0].strip(), queries[1].strip());
+        boolean isUnique = userTasks.add(task);
+        if (!isUnique) {
+            return getDuplicateMessage();
+        }
+        return formatAdd(task);
+    }
+}

--- a/src/main/java/duke/views/cli/strategies/commands/AddTodoCommand.java
+++ b/src/main/java/duke/views/cli/strategies/commands/AddTodoCommand.java
@@ -1,0 +1,31 @@
+package duke.views.cli.strategies.commands;
+
+import duke.domain.Task;
+import duke.domain.TaskList;
+import duke.domain.Todo;
+
+public class AddTodoCommand extends TaskCommand {
+    private static Command singleInstance;
+
+    public AddTodoCommand(TaskList taskList) {
+        super(taskList);
+    }
+
+    public static Command getInstance(TaskList taskList) {
+        if (singleInstance == null) {
+            singleInstance = new AddTodoCommand(taskList);
+        }
+        return singleInstance;
+    }
+
+    @Override
+    public String produce(String query) {
+        assert query != null;
+        Task task = new Todo(query.substring(todo.length()).strip());
+        boolean isUnique = userTasks.add(task);
+        if (!isUnique) {
+            return getDuplicateMessage();
+        }
+        return formatAdd(task);
+    }
+}

--- a/src/main/java/duke/views/cli/strategies/commands/ByeCommand.java
+++ b/src/main/java/duke/views/cli/strategies/commands/ByeCommand.java
@@ -1,0 +1,17 @@
+package duke.views.cli.strategies.commands;
+
+public class ByeCommand extends Command {
+    private static Command singleInstance;
+
+    public static Command getInstance() {
+        if (singleInstance == null) {
+            singleInstance = new ByeCommand();
+        }
+        return singleInstance;
+    }
+
+    @Override
+    public String produce(String _query) {
+        return "See you again" + System.lineSeparator();
+    }
+}

--- a/src/main/java/duke/views/cli/strategies/commands/Command.java
+++ b/src/main/java/duke/views/cli/strategies/commands/Command.java
@@ -1,0 +1,14 @@
+package duke.views.cli.strategies.commands;
+
+import duke.interfaces.StringProducer;
+
+public abstract class Command implements StringProducer {
+    protected final String list = "list";
+    protected final String done = "done";
+    protected final String todo = "todo";
+    protected final String deadline = "deadline";
+    protected final String event = "event";
+    protected final String delete = "delete";
+    protected final String on = "on";
+    protected final String find = "find";
+}

--- a/src/main/java/duke/views/cli/strategies/commands/DeleteCommand.java
+++ b/src/main/java/duke/views/cli/strategies/commands/DeleteCommand.java
@@ -1,0 +1,36 @@
+package duke.views.cli.strategies.commands;
+
+import duke.domain.Task;
+import duke.domain.TaskList;
+import duke.shared.DukeException;
+
+public class DeleteCommand extends TaskCommand {
+    private static Command singleInstance;
+
+    public DeleteCommand(TaskList taskList) {
+        super(taskList);
+    }
+
+    public static Command getInstance(TaskList taskList) {
+        if (singleInstance == null) {
+            singleInstance = new DeleteCommand(taskList);
+        }
+        return singleInstance;
+    }
+
+    @Override
+    public String produce(String query) throws DukeException {
+        assert query != null;
+        try {
+            int index = Integer.parseInt(query.substring(delete.length()).strip()) - 1;
+            if (index >= userTasks.size() || index < 0) {
+                throw DukeException.createIndexOutOfBoundsException(userTasks.size(), index + 1);
+            }
+            Task removedTask = userTasks.remove(index);
+            return String.format("Noted. I've removed this task:%s%s%s%s%s", System.lineSeparator(), removedTask,
+                    System.lineSeparator(), formatTaskCount(), System.lineSeparator());
+        } catch (NumberFormatException e) {
+            throw new DukeException(DukeException.ExceptionCode.INCORRECT_ARGS, "Please give a number");
+        }
+    }
+}

--- a/src/main/java/duke/views/cli/strategies/commands/FindCommand.java
+++ b/src/main/java/duke/views/cli/strategies/commands/FindCommand.java
@@ -1,0 +1,35 @@
+package duke.views.cli.strategies.commands;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import duke.domain.Task;
+import duke.domain.TaskList;
+
+
+
+public class FindCommand extends TaskCommand {
+    private static Command singleInstance;
+
+    public FindCommand(TaskList taskList) {
+        super(taskList);
+    }
+
+    public static Command getInstance(TaskList taskList) {
+        if (singleInstance == null) {
+            singleInstance = new FindCommand(taskList);
+        }
+        return singleInstance;
+    }
+
+    @Override
+    public String produce(String query) {
+        assert query != null;
+        String keyword = query.substring(find.length()).strip();
+        List<Task> filteredTasks = userTasks.stream()
+                .filter(task -> task.match(keyword))
+                .collect(Collectors.toList());
+        return listTasksWithMessage("Here are the matching tasks in your list:",
+                new TaskList(filteredTasks), "No matches found");
+    }
+}

--- a/src/main/java/duke/views/cli/strategies/commands/ListCommand.java
+++ b/src/main/java/duke/views/cli/strategies/commands/ListCommand.java
@@ -1,0 +1,24 @@
+package duke.views.cli.strategies.commands;
+
+import duke.domain.TaskList;
+
+public class ListCommand extends TaskCommand {
+    private static Command singleInstance;
+
+    public ListCommand(TaskList taskList) {
+        super(taskList);
+    }
+
+    public static Command getInstance(TaskList taskList) {
+        if (singleInstance == null) {
+            singleInstance = new ListCommand(taskList);
+        }
+        return singleInstance;
+    }
+
+    @Override
+    public String produce(String _query) {
+        return listTasksWithMessage("Here are the tasks in your list:",
+                userTasks, "You're clear (for now)");
+    }
+}

--- a/src/main/java/duke/views/cli/strategies/commands/MarkDoneCommand.java
+++ b/src/main/java/duke/views/cli/strategies/commands/MarkDoneCommand.java
@@ -1,0 +1,38 @@
+package duke.views.cli.strategies.commands;
+
+import duke.domain.Task;
+import duke.domain.TaskList;
+import duke.shared.DukeException;
+
+public class MarkDoneCommand extends TaskCommand {
+    private static Command singleInstance;
+
+    public MarkDoneCommand(TaskList taskList) {
+        super(taskList);
+    }
+
+    public static Command getInstance(TaskList taskList) {
+        if (singleInstance == null) {
+            singleInstance = new MarkDoneCommand(taskList);
+        }
+        return singleInstance;
+    }
+
+    @Override
+    public String produce(String query) throws DukeException {
+        assert query != null;
+        try {
+            int index = Integer.parseInt(query.substring(done.length()).strip()) - 1;
+            boolean isWithinBounds = index >= userTasks.size() || index < 0;
+            if (!isWithinBounds) {
+                throw DukeException.createIndexOutOfBoundsException(userTasks.size(), index + 1);
+            }
+            Task task = userTasks.get(index);
+            task.finish();
+            return String.format("Nice! I've marked this task as done:%s\t%s%s", System.lineSeparator(), task,
+                    System.lineSeparator());
+        } catch (NumberFormatException e) {
+            throw new DukeException(DukeException.ExceptionCode.INCORRECT_ARGS, "Please give a number");
+        }
+    }
+}

--- a/src/main/java/duke/views/cli/strategies/commands/OccurringOnCommand.java
+++ b/src/main/java/duke/views/cli/strategies/commands/OccurringOnCommand.java
@@ -1,0 +1,52 @@
+package duke.views.cli.strategies.commands;
+
+import java.time.LocalDateTime;
+
+import duke.constants.Constants;
+import duke.domain.Deadline;
+import duke.domain.Event;
+import duke.domain.Task;
+import duke.domain.TaskList;
+import duke.shared.DukeException;
+
+public class OccurringOnCommand extends TaskCommand {
+    private static Command singleInstance;
+
+    public OccurringOnCommand(TaskList taskList) {
+        super(taskList);
+    }
+
+    public static Command getInstance(TaskList taskList) {
+        if (singleInstance == null) {
+            singleInstance = new OccurringOnCommand(taskList);
+        }
+        return singleInstance;
+    }
+
+    @Override
+    public String produce(String query) throws DukeException {
+        assert query != null;
+        String dateQuery = query.substring(on.length()).strip();
+        if (dateQuery.length() == 0) {
+            dateQuery = Constants.Input.DATETIME_FORMATTER.format(LocalDateTime.now());
+        }
+
+        TaskList relevantTasks = new TaskList();
+        for (Task task : userTasks) {
+            if (task instanceof Deadline) {
+                Deadline deadline = (Deadline) task;
+                if (deadline.isDueOn(dateQuery)) {
+                    relevantTasks.add(deadline);
+                }
+            } else if (task instanceof Event) {
+                Event event = (Event) task;
+                if (event.isOccurringOnDay(dateQuery)) {
+                    relevantTasks.add(event);
+                }
+            }
+        }
+
+        return listTasksWithMessage("Tasks occurring on that day:",
+                relevantTasks, "No tasks on that day");
+    }
+}

--- a/src/main/java/duke/views/cli/strategies/commands/TaskCommand.java
+++ b/src/main/java/duke/views/cli/strategies/commands/TaskCommand.java
@@ -1,0 +1,50 @@
+package duke.views.cli.strategies.commands;
+
+import duke.domain.Task;
+import duke.domain.TaskList;
+
+
+
+
+public abstract class TaskCommand extends Command {
+    protected final TaskList userTasks;
+
+    public TaskCommand(TaskList userTasks) {
+        this.userTasks = userTasks;
+    }
+
+    protected String stringifyTasks(TaskList tasks) {
+        String result = "";
+        for (int i = 0; i < tasks.size(); i++) {
+            result += String.format("%d. %s%s", (i + 1), tasks.get(i), System.lineSeparator());
+        }
+        return result;
+    }
+
+    protected String listTasksWithMessage(String message, TaskList tasks, String emptyMessage) {
+        if (tasks.size() == 0) {
+            return emptyMessage + System.lineSeparator();
+        }
+        String result = message + System.lineSeparator();
+
+        result += stringifyTasks(tasks);
+        return result;
+    }
+
+    protected String formatTaskCount() {
+        String s = "";
+        if (userTasks.size() != 1) {
+            s = "s";
+        }
+        return String.format("Now you have %d task%s in the list.", userTasks.size(), s);
+    }
+
+    protected String formatAdd(Task t) {
+        return String.format("Got it. I've added this task:%s%s%s%s%s", System.lineSeparator(), t,
+                System.lineSeparator(), formatTaskCount(), System.lineSeparator());
+    }
+
+    protected String getDuplicateMessage() {
+        return "Note: You have attempted to add a duplicate task. It will not be added again." + System.lineSeparator();
+    }
+}

--- a/src/main/java/duke/views/gui/Gui.java
+++ b/src/main/java/duke/views/gui/Gui.java
@@ -3,12 +3,12 @@ package duke.views.gui;
 import duke.views.InteractionLayer;
 import duke.views.cli.Greeter;
 import duke.views.cli.Loader;
-import duke.views.cli.strategies.RespondWith;
+import duke.views.cli.strategies.RespondWithDelegated;
 
 public class Gui implements InteractionLayer {
     protected Loader loader;
     protected Greeter greeter;
-    protected RespondWith responder;
+    protected RespondWithDelegated responder;
 
     /**
      * Creates an instance equipped with a responder.
@@ -16,7 +16,7 @@ public class Gui implements InteractionLayer {
      * @param responder A parser of user input and generates a suitable response
      *                  when fed input.
      */
-    public Gui(RespondWith responder) {
+    public Gui(RespondWithDelegated responder) {
         loader = new Loader();
         greeter = new Greeter();
         this.responder = responder;
@@ -33,7 +33,7 @@ public class Gui implements InteractionLayer {
     }
 
     @Override
-    public RespondWith getResponder() {
+    public RespondWithDelegated getResponder() {
         return responder;
     }
 

--- a/src/main/java/duke/views/gui/Launcher.java
+++ b/src/main/java/duke/views/gui/Launcher.java
@@ -2,7 +2,7 @@ package duke.views.gui;
 
 import java.io.IOException;
 
-import duke.views.cli.strategies.MultiType;
+import duke.views.cli.strategies.MultiTypeDelegated;
 import duke.views.gui.controllers.MainWindow;
 import javafx.application.Application;
 import javafx.fxml.FXMLLoader;
@@ -16,7 +16,7 @@ public class Launcher extends Application {
     @Override
     public void start(Stage stage) {
         try {
-            this.gui = new Gui(new MultiType());
+            this.gui = new Gui(new MultiTypeDelegated());
             this.gui.initCallbacks();
             FXMLLoader fxmlLoader = new FXMLLoader(MainWindow.class.getResource("/view/MainWindow.fxml"));
             AnchorPane ap = fxmlLoader.load();


### PR DESCRIPTION
MultiType class methods have become numerous and make the class messy.

Move each method to a separate Command subclass.

Extracting the method behavior to a separate command class reduces
coupling and makes the Responder class less bulky.

Let's create a Command class to encapsulate all commands that respond
to user input and generate a response string.

Encapsulation is better than storing all methods in a single class
as this improves code organization.